### PR TITLE
fix generics error for RouteDefinitionGroup

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -33,10 +33,10 @@ export type ParameterDefinition =
 
 export type QueryParameterDefinitionCollection = {
   [parameterName: string]:
-    | QueryParamNumber
-    | QueryParamString
-    | QueryParamNumberOptional
-    | QueryParamStringOptional;
+  | QueryParamNumber
+  | QueryParamString
+  | QueryParamNumberOptional
+  | QueryParamStringOptional;
 };
 
 export type ParameterDefinitionCollection = {
@@ -149,11 +149,11 @@ export type HistoryConfig =
 
 export type RouteDefinitionToRoute<
   T extends RouteDefinition<string, ParameterDefinitionCollection>
-> = {
-  name: T["name"];
-  action: Action;
-  params: RouteParameters<T[".builder"]["params"]>;
-};
+  > = {
+    name: T["name"];
+    action: Action;
+    params: RouteParameters<T[".builder"]["params"]>;
+  };
 
 export type NotFoundRoute = {
   name: false;
@@ -161,7 +161,13 @@ export type NotFoundRoute = {
   params: {};
 };
 
-export type RouteDefinitionGroup<T extends any> = {
+export type RouteDefinitionGroup<T extends {
+  [key: number]: {
+    '.type': {
+      name: any[],
+    }
+  }
+}> = {
   [".type"]: T[number][".type"];
   routeNames: T[number][".type"]["name"][];
   has(route: Route<any>): route is T[number][".type"];
@@ -172,18 +178,18 @@ export type Route<T> = T extends RouteDefinition<any, any>
   : T extends RouteDefinitionGroup<any>
   ? T[".type"]
   :
-      | {
-          [K in keyof T]: {
-            name: K;
-            action: Action;
-            params: T[K] extends RouteDefinition<any, any>
-              ? RouteParameters<T[K][".builder"]["params"]>
-              : T[K] extends RouteDefinitionBuilder<any>
-              ? RouteParameters<T[K]["params"]>
-              : never;
-          };
-        }[keyof T]
-      | NotFoundRoute;
+  | {
+    [K in keyof T]: {
+      name: K;
+      action: Action;
+      params: T[K] extends RouteDefinition<any, any>
+      ? RouteParameters<T[K][".builder"]["params"]>
+      : T[K] extends RouteDefinitionBuilder<any>
+      ? RouteParameters<T[K]["params"]>
+      : never;
+    };
+  }[keyof T]
+  | NotFoundRoute;
 
 export type NavigationHandler<T> = (
   nextRoute: Route<T>


### PR DESCRIPTION
when I run `tsc` with type-router, I get the following errors:

```
node_modules/type-route/lib/types.d.ts:110:16 - error TS2536: Type 'number' cannot be used to index type 'T'.

110     [".type"]: T[number][".type"];
                   ~~~~~~~~~

node_modules/type-route/lib/types.d.ts:110:16 - error TS2536: Type '".type"' cannot be used to index type 'T[number]'.

110     [".type"]: T[number][".type"];
                   ~~~~~~~~~~~~~~~~~~

node_modules/type-route/lib/types.d.ts:111:17 - error TS2536: Type 'number' cannot be used to index type 'T'.

111     routeNames: T[number][".type"]["name"][];
                    ~~~~~~~~~

node_modules/type-route/lib/types.d.ts:111:17 - error TS2536: Type '".type"' cannot be used to index type 'T[number]'.

111     routeNames: T[number][".type"]["name"][];
                    ~~~~~~~~~~~~~~~~~~

node_modules/type-route/lib/types.d.ts:111:17 - error TS2536: Type '"name"' cannot be used to index type 'T[number][".type"]'.

111     routeNames: T[number][".type"]["name"][];
                    ~~~~~~~~~~~~~~~~~~~~~~~~~~

node_modules/type-route/lib/types.d.ts:112:38 - error TS2536: Type 'number' cannot be used to index type 'T'.

112     has(route: Route<any>): route is T[number][".type"];
                                         ~~~~~~~~~

node_modules/type-route/lib/types.d.ts:112:38 - error TS2536: Type '".type"' cannot be used to index type 'T[number]'.

112     has(route: Route<any>): route is T[number][".type"];
                                         ~~~~~~~~~~~~~~~~~~


Found 7 errors.
```

this PR fixes those errors